### PR TITLE
Add a copy to clipboard link next to firefox arguments

### DIFF
--- a/src/components/ConnectionContainer.css
+++ b/src/components/ConnectionContainer.css
@@ -21,13 +21,28 @@
 }
 
 #connection-help {
-  margin-top: 10px;
+  margin-bottom: 10px;
   font-size: 0.8em;
 }
 
 #connection-help span {
-  background-color: #aaa;
-  color: white;
-  padding: 3px 6px;
-  border-radius: 2px;
+  border: 1px solid var(--highlight);
+  color: var(--highlight);
+  padding: 2px 4px;
+  border-radius: 0px;
 }
+
+#copy-to-clipboard {
+  border: none;
+  background: transparent;
+  color: var(--highlight);
+  cursor: pointer;
+  text-decoration: underline;
+  visibility: hidden;
+}
+
+#connection-help:hover #copy-to-clipboard {
+  visibility: visible;
+}
+
+

--- a/src/components/ConnectionContainer.js
+++ b/src/components/ConnectionContainer.js
@@ -11,9 +11,31 @@ const ConnectionContainer = ({
     return null;
   }
 
+  const connectionArguments = `--remote-debugging-port --remote-allow-origins=${window.location.origin}`;
+
   return (
     <div id="connection-container">
       <h4>Connect to Firefox</h4>
+      <div id="connection-help">
+        Start Firefox with{" "}
+        <span id="connection-help-arguments">
+          {connectionArguments}
+        </span>
+        <button
+          id="copy-to-clipboard"
+          onClick={(event) => {
+            event.stopPropagation();
+            navigator.clipboard.writeText(connectionArguments);
+
+            event.target.textContent = "copied!";
+            window.setTimeout(
+              () => (event.target.textContent = "copy to clipboard"),
+              1000
+            );
+          }}>
+          copy to clipboard
+        </button>
+      </div>
       <div>
         <input
           type="text"
@@ -30,13 +52,6 @@ const ConnectionContainer = ({
         >
           connect
         </button>
-      </div>
-      <div id="connection-help">
-        Start Firefox with{" "}
-        <span id="connection-help-arguments">
-          --remote-debugging-port --remote-allow-origins=
-          {window.location.origin}
-        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
Tiny UI update for the connection area:

from

<img width="636" alt="image" src="https://user-images.githubusercontent.com/1141550/193295945-b94a5056-19f4-4296-a8a4-826f3a079787.png">

to 

<img width="673" alt="image" src="https://user-images.githubusercontent.com/1141550/193295618-6218f6c3-f812-449b-8b51-73b1980e3ee7.png">

With a "copy to clipboard" link appearing on hover

<img width="607" alt="image" src="https://user-images.githubusercontent.com/1141550/193295762-756d9c53-4227-4e36-9715-71301d7a2422.png">
