### PR TITLE
Network summary

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -8,11 +8,6 @@
   max-height: 100%;
 }
 
-.network-app {
-  max-height: 100%;
-  overflow-y: hidden;
-}
-
 .webconsole-app {
   max-height: 100%;
   overflow-y: scroll;

--- a/src/components/Network.css
+++ b/src/components/Network.css
@@ -10,6 +10,14 @@
   --table-zebra-background: rgba(247, 247, 247, 0.8);
 }
 
+.network-app {
+  display: grid;
+  font-size: 11px;
+  grid-template-rows: auto auto 25px;
+  max-height: 100%;
+  overflow-y: hidden;
+}
+
 .network-header {
   border-bottom: 1px solid var(--theme-splitter-color);
 }
@@ -24,8 +32,18 @@
 }
 
 .network-entries {
-  max-height: calc(100% - 21px);
+  max-height: 100%;
   overflow: auto;
+}
+
+.network-footer {
+  position: fixed;
+  bottom: 0;
+  display: flex;
+  width: 100%;
+  height: 25px;
+  border-top: 1px solid var(--theme-splitter-color);
+  background: var(--theme-tab-toolbar-background);
 }
 
 .network-column {
@@ -36,8 +54,8 @@
 }
 
 .network-row {
+  position: relative;
   display: grid;
-  font-size: 11px;
   height: 20px;
   grid-template-columns: 40px 40px 70px auto;
 }
@@ -49,4 +67,38 @@
 .network-row:hover,
 .network-row:nth-child(odd):hover {
   background: var(--table-selection-background-hover);
+}
+
+.network-first-request:after {
+  content: "NAVIGATION";
+  position: absolute;
+  right: 0;
+
+  height: 14px;
+  margin: 3px 3px 0 0;
+  padding: 0 3px;
+
+  display: flex;
+  align-items: center;
+
+  font-size: 9px;
+  background: var(--tab-line-selected-color);
+  border-radius: 2px;
+  color: var(--theme-selection-color);
+}
+
+.network-first-request,
+.network-first-request:nth-child(odd) {
+  background: rgba(227, 239, 251, 0.8);
+}
+
+.network-summary-item{
+  height: 100%;
+  padding: 0 5px;
+  display: flex;
+  align-items: center;
+}
+
+.network-summary-item:not(:last-child) {
+  border-right: 1px solid var(--theme-splitter-color);
 }

--- a/src/components/Network.js
+++ b/src/components/Network.js
@@ -1,13 +1,17 @@
 import "./Network.css";
 
 const Network = ({
-  networkEntries,
-  isClientReady,
   filteringBrowsingContextId,
+  isClientReady,
+  networkEntries,
+  pageTimings,
 }) => {
   if (!isClientReady) {
     return null;
   }
+
+  const entries = networkEntries.filter(({ contextId }) =>
+            !filteringBrowsingContextId || (filteringBrowsingContextId === contextId));
 
   return (
     <div className="network-app">
@@ -28,30 +32,39 @@ const Network = ({
         </div>
       </div>
       <div className="network-entries">
-        {networkEntries.map(
+        {entries.map(
           ({
-            contextId,
-            url,
+            isFirstRequest,
             request,
             response,
+            url,
           }) =>
-            !filteringBrowsingContextId || (filteringBrowsingContextId === contextId) ? (
-              <div className="network-row">
-                <span className="network-column network-column-status">
-                  {response?.status}
-                </span>
-                <span className="network-column network-column-status">
-                  {request.method}
-                </span>
-                <span className="network-column network-column-status">
-                  {response?.protocol}
-                </span>
-                <span className="network-column network-column-status ellipsis-text">
-                  {request.url}
-                </span>
-              </div>
-            ) : null
+            <div className={`network-row ${isFirstRequest ? 'network-first-request' : ''}`}>
+              <span className="network-column network-column-status">
+                {response?.status}
+              </span>
+              <span className="network-column network-column-status">
+                {request.method}
+              </span>
+              <span className="network-column network-column-status">
+                {response?.protocol}
+              </span>
+              <span className="network-column network-column-status ellipsis-text">
+                {request.url}
+              </span>
+            </div>
         )}
+      </div>
+      <div className="network-footer">
+        <span className="network-summary-item">
+          {entries.length} requests
+        </span>
+        <span className="network-summary-item network-summary-timing">
+          DOMContentLoaded: {pageTimings.findLast(t => t.type === "domContentLoaded")?.relativeTime}ms
+        </span>
+        <span className="network-summary-item network-summary-timing">
+          load: {pageTimings.findLast(t => t.type === "load")?.relativeTime}ms
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
This PR adds a summary footer in the network tab, showing the latest DOMContentLoaded / load, as well as the total number of request.

Most importantly this keeps track for the browsingContext events `load` and `domContentLoaded`, which will be used for HAR export.

The "navigation" requests are also highlighted with a special color and a small badge to help understanding which navigation various requests relate to. Of course this is less relevant when several contexts / frames start doing requests in parallel, but it could be a visual aid for basic use cases.

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/1141550/214005491-564e8102-3e4b-4d57-9b82-3a9da4803f81.png">
