### PR TITLE
Add button in network panel to export as HAR

### DIFF
--- a/src/assets/file.svg
+++ b/src/assets/file.svg
@@ -1,0 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="context-fill">
+  <path d="M2 4a3 3 0 0 1 3-3h4.17a3 3 0 0 1 2.12.88l1.83 1.83A3 3 0 0 1 14 5.83V12a3 3 0 0 1-3 3H5a3 3 0 0 1-3-3V4zm3-1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V5.83a1 1 0 0 0-.3-.7L9.89 3.28a1 1 0 0 0-.7-.29H5z"/>
+  <path d="M6 10.5c0-.28.22-.5.5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5zM6 8.5c0-.28.22-.5.5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5zM6 6.5c0-.28.22-.5.5-.5h1a.5.5 0 0 1 0 1h-1a.5.5 0 0 1-.5-.5zM9 4.5V3h1v1.5c0 .28.22.5.5.5H12v1h-1.5A1.5 1.5 0 0 1 9 4.5z"/>
+</svg>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -303,10 +303,11 @@ class App extends React.Component {
         entry.contextId === context && entry.request.url === url
       );
 
-      let relativeTime = +Infinity;
+      let relativeTime = +Infinity, startedTime = -1;
       if (firstRequest) {
         const timings = firstRequest.request.timings;
-        relativeTime = timestamp - (timings.requestTime / 1000);
+        startedTime = timings.requestTime / 1000;
+        relativeTime = timestamp - startedTime;
         relativeTime = relativeTime.toFixed(1);
         firstRequest.isFirstRequest = true;
       }
@@ -317,6 +318,7 @@ class App extends React.Component {
           {
             contextId: context,
             relativeTime,
+            startedTime,
             timestamp,
             type,
             url,

--- a/src/components/Network.css
+++ b/src/components/Network.css
@@ -36,16 +36,6 @@
   overflow: auto;
 }
 
-.network-footer {
-  position: fixed;
-  bottom: 0;
-  display: flex;
-  width: 100%;
-  height: 25px;
-  border-top: 1px solid var(--theme-splitter-color);
-  background: var(--theme-tab-toolbar-background);
-}
-
 .network-column {
   padding-block: 3px;
   padding-inline-start: 5px;
@@ -90,15 +80,4 @@
 .network-first-request,
 .network-first-request:nth-child(odd) {
   background: rgba(227, 239, 251, 0.8);
-}
-
-.network-summary-item{
-  height: 100%;
-  padding: 0 5px;
-  display: flex;
-  align-items: center;
-}
-
-.network-summary-item:not(:last-child) {
-  border-right: 1px solid var(--theme-splitter-color);
 }

--- a/src/components/Network.js
+++ b/src/components/Network.js
@@ -1,3 +1,5 @@
+import React from "react";
+import NetworkFooter from "./NetworkFooter";
 import "./Network.css";
 
 const Network = ({
@@ -6,11 +8,15 @@ const Network = ({
   networkEntries,
   pageTimings,
 }) => {
+
   if (!isClientReady) {
     return null;
   }
 
   const entries = networkEntries.filter(({ contextId }) =>
+            !filteringBrowsingContextId || (filteringBrowsingContextId === contextId));
+
+  const timings = pageTimings.filter(({ contextId }) =>
             !filteringBrowsingContextId || (filteringBrowsingContextId === contextId));
 
   return (
@@ -55,17 +61,10 @@ const Network = ({
             </div>
         )}
       </div>
-      <div className="network-footer">
-        <span className="network-summary-item">
-          {entries.length} requests
-        </span>
-        <span className="network-summary-item network-summary-timing">
-          DOMContentLoaded: {pageTimings.findLast(t => t.type === "domContentLoaded")?.relativeTime}ms
-        </span>
-        <span className="network-summary-item network-summary-timing">
-          load: {pageTimings.findLast(t => t.type === "load")?.relativeTime}ms
-        </span>
-      </div>
+      <NetworkFooter
+        filteredNetworkEntries={entries}
+        filteredPageTimings={timings}
+      />
     </div>
   );
 };

--- a/src/components/NetworkFooter.css
+++ b/src/components/NetworkFooter.css
@@ -1,0 +1,36 @@
+
+
+.network-footer {
+  position: fixed;
+  bottom: 0;
+  display: flex;
+  width: 100%;
+  height: 25px;
+  border-top: 1px solid var(--theme-splitter-color);
+  background: var(--theme-tab-toolbar-background);
+}
+
+.network-summary-item{
+  height: 100%;
+  padding: 0 5px;
+  display: flex;
+  align-items: center;
+}
+
+.network-summary-item:not(:last-child) {
+  border-right: 1px solid var(--theme-splitter-color);
+}
+
+.network-har-export-button {
+  background-image: url("../assets/file.svg");
+  background-repeat: no-repeat;
+  background-position: 3px;
+  padding-left: 20px;
+  position: absolute;
+  right: 0;
+  cursor: default;
+}
+
+.network-har-export-button:hover {
+  background-color: var(--theme-toolbar-hover);
+}

--- a/src/components/NetworkFooter.js
+++ b/src/components/NetworkFooter.js
@@ -1,0 +1,52 @@
+import React from "react";
+import "./NetworkFooter.css";
+
+import { exportAsHAR } from "../har.js";
+
+class NetworkFooter extends React.Component {
+  #onHarButtonClick = (entries, timings) => {
+    const har = exportAsHAR(entries, timings);
+    const blob = new Blob([JSON.stringify(har, null, 2)], {
+      type: "application/json",
+    });
+
+    // Create a fake download link and trigger the download.
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.style.display = 'none';
+    a.href = url;
+    a.download = `bidi-har-${new Date().toISOString()}.har`;
+    document.body.appendChild(a);
+    a.click();
+    window.URL.revokeObjectURL(url);
+  }
+
+  render() {
+    const {
+      filteredNetworkEntries,
+      filteredPageTimings,
+    } = this.props;
+
+    return (
+      <div className="network-footer">
+        <span className="network-summary-item">
+          {filteredNetworkEntries.length} requests
+        </span>
+        <span className="network-summary-item network-summary-timing">
+          DOMContentLoaded: {filteredPageTimings.findLast(t => t.type === "domContentLoaded")?.relativeTime}ms
+        </span>
+        <span className="network-summary-item network-summary-timing">
+          load: {filteredPageTimings.findLast(t => t.type === "load")?.relativeTime}ms
+        </span>
+        <span
+          className="network-summary-item network-har-export-button"
+          onClick={() => this.#onHarButtonClick(filteredNetworkEntries, filteredPageTimings)}
+        >
+          Save all as HAR
+        </span>
+      </div>
+    );
+  }
+}
+
+export default NetworkFooter;

--- a/src/har.js
+++ b/src/har.js
@@ -1,0 +1,183 @@
+const HAR_VERSION = "1.2";
+const BROWSER_NAME = "Firefox";
+const BROWSER_VERSION = "111.0a1";
+
+function parseQueryString(url) {
+  try {
+    const urlObject = new URL(url);
+    return [...urlObject.searchParams.entries()].map(([name, value]) => {
+      return {
+        name: decodeURIComponent(name),
+        value: decodeURIComponent(value),
+      };
+    });
+  } catch (e) {
+    console.error("Failed to parse query string for url", url);
+    console.error(e);
+    return [];
+  }
+}
+
+function getBrowser() {
+  const name = BROWSER_NAME;
+  const version = BROWSER_VERSION;
+  return { name, version };
+}
+
+function getCreator() {
+  const name = BROWSER_NAME;
+  const version = BROWSER_VERSION;
+  return { name, version };
+}
+
+function getHAREntry(networkEntry) {
+  const harEntry = {};
+
+  // Most of the default values (eg "?" or -1 or []) are needed for cached
+  // responses which currently don't come with enough information.
+  // See https://bugzilla.mozilla.org/show_bug.cgi?id=1806802
+  harEntry.request = {
+    bodySize: networkEntry.request.bodySize,
+    method: networkEntry.request.method,
+    url: networkEntry.request.url,
+    httpVersion: networkEntry.response.protocol || "?",
+    headers: networkEntry.request.headers,
+    cookies: networkEntry.request.cookies,
+    queryString: parseQueryString(networkEntry.request.url) || [],
+    headersSize: networkEntry.request.headersSize,
+  };
+
+  const timings = networkEntry.request.timings;
+  harEntry.startedTime = timings.requestTime / 1000;
+  harEntry.startedDateTime = new Date(harEntry.startedTime).toISOString();
+  harEntry.response = {
+    status: networkEntry.response.status || -1,
+    statusText: networkEntry.response.statusText || "?",
+    httpVersion: networkEntry.response.protocol || "?",
+    headers: networkEntry.response.headers || [],
+    cookies: [],
+    content: {
+      mimeType: networkEntry.response.mimeType || "?",
+      size: networkEntry.response.content.size,
+      encoding: "",
+      text: "",
+      comment: "",
+      compression: "",
+    },
+    redirectURL: "",
+    headersSize: networkEntry.response.headersSize,
+    bodySize: networkEntry.response.bytesReceived,
+  };
+
+  // XXX: Check where this comes from in devtools.
+  harEntry.cache = {};
+  harEntry.timings = {};
+
+  // Convert from BiDi timings to HAR timings
+  let last = timings.requestTime;
+  harEntry.timings.blocked = (timings.dnsStart - last) / 1000;
+
+  last = timings.dnsStart || last;
+  harEntry.timings.dns = (timings.dnsEnd - timings.dnsStart) / 1000;
+
+  last = timings.connectStart || last;
+  harEntry.timings.connect = (timings.connectEnd - last) / 1000;
+
+  last = timings.tlsStart || last;
+  harEntry.timings.ssl = (timings.tlsEnd - last) / 1000;
+
+  last = timings.tlsEnd || last;
+  harEntry.timings.send = (timings.requestStart - last) / 1000;
+
+  last = timings.requestStart || last;
+  harEntry.timings.wait = (timings.responseStart - last) / 1000;
+
+  last = timings.responseStart || last;
+  harEntry.timings.receive = (timings.responseEnd - last) / 1000;
+
+  let time = 0;
+  for (const key of Object.keys(harEntry.timings)) {
+    harEntry.timings[key] = Math.max(0, harEntry.timings[key]);
+    time += harEntry.timings[key];
+  }
+
+  harEntry.time = time;
+  return harEntry;
+}
+
+export const exportAsHAR = (networkEntries, pageTimings) => {
+  const recording = {
+    log: {
+      version: HAR_VERSION,
+      creator: getCreator(),
+      browser: getBrowser(),
+      pages: [],
+      entries: [],
+    },
+  };
+
+  const pages = [];
+  for (const pageTiming of pageTimings) {
+    // Check if there is already a page item in this recording for the same URL.
+    // Also exclude page entries which already have a timing corresponding to
+    // the type ("load", "domContentLoaded"...), which would indicate another
+    // navigation to the same URL.
+    let page = pages.find(p => p.url === pageTiming.url && !p.pageTimings[pageTiming.type]);
+    if (!page) {
+      // Create a base page record.
+      page = {
+        id: `page_${pages.length + 1}`,
+        pageTimings: {},
+        startedDateTime: new Date(pageTiming.startedTime).toISOString(),
+        title: pageTiming.url,
+        // startedTime and url are temporary properties, and will be deleted
+        // before generating the HAR.
+        startedTime: pageTiming.startedTime,
+        url: pageTiming.url,
+      };
+      pages.push(page);
+    }
+
+    // Add the timing, which is the relative time for either DOMContentLoaded or Load
+    page.pageTimings[pageTiming.type] = pageTiming.relativeTime;
+  }
+
+  recording.log.pages = pages;
+
+  for (const networkEntry of networkEntries) {
+    if (!networkEntry.response) {
+      // Redirected requests are currently not emitting the responseStarted
+      // responseCompleted events because they are triggered out of order.
+      // See https://bugzilla.mozilla.org/show_bug.cgi?id=1809210
+      // In the meantime, ignore entries with a missing `response`.
+      continue;
+    }
+
+    const entry = getHAREntry(networkEntry);
+    for (const page of recording.log.pages) {
+      if (page.startedTime <= entry.startedTime) {
+        entry.pageref = page.id;
+      }
+    }
+    delete entry.startedTime;
+    recording.log.entries.push(entry);
+  }
+
+  for (const page of recording.log.pages) {
+    // Rename timings
+    page.pageTimings.onContentLoad = page.pageTimings.domContentLoaded * 1;
+    page.pageTimings.onLoad = page.pageTimings.load * 1;
+
+    // Delete temporary fields
+    delete page.pageTimings.domContentLoaded;
+    delete page.pageTimings.load;
+    delete page.startedTime;
+    delete page.url;
+  }
+
+  recording.log.entries = recording.log.entries.sort((e1, e2) => {
+    return e1.request.timestamp - e2.request.timestamp;
+  });
+
+  return recording;
+};


### PR DESCRIPTION
- adds a new NetworkFooter component, which now shows a "Save all as HAR" button on the right side
- adds a har.js helper module
- clicking on the  "Save all as HAR" button downloads a HAR of all the displayed requests as a file
- takes the selected context into account

You should normally be able to view HAR files generated with this feature using http://www.softwareishard.com/har/viewer/ but there might still be edge cases where the we don't build a fully valid HAR files.

 <img width="275" alt="image" src="https://user-images.githubusercontent.com/1141550/214166862-bece155e-ff3b-484c-8677-4eed935bef7b.png">
