### PR TITLE
Update har export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@codemirror/lang-javascript": "6.1.0",
         "@codemirror/state": "6.1.2",
         "@codemirror/view": "6.2.5",
-        "bidi-har-export": "juliandescottes/bidi-har-export#b2dc5b5d6fa90cdddb41c40681dc25119a37cd95",
+        "bidi-har-export": "firefox-devtools/bidi-har-export#b92585f39b6640ec93e57b0395b4dc22c2bde666",
         "codemirror": "6.0.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -4938,8 +4938,8 @@
     },
     "node_modules/bidi-har-export": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/juliandescottes/bidi-har-export.git#b2dc5b5d6fa90cdddb41c40681dc25119a37cd95",
-      "integrity": "sha512-LTO6Nwzf/MvvA32Uozr4FXECVivwJAV7Wjh0EA/wX7Cj5qoI1gu4/YsVUWNpc9ERFE3yhCSwuXXSOhjqxvinUw==",
+      "resolved": "git+ssh://git@github.com/firefox-devtools/bidi-har-export.git#b92585f39b6640ec93e57b0395b4dc22c2bde666",
+      "integrity": "sha512-HsPe74TZ8FdeRek1aaL8SEG+xy8i0cTHiHj1Vf1GjKPlRaPbj9dXrheN49Br5H++1hknSEoR2PorAEgWyfH3yw==",
       "license": "MPL-2.0"
     },
     "node_modules/big.js": {
@@ -19943,9 +19943,9 @@
       }
     },
     "bidi-har-export": {
-      "version": "git+ssh://git@github.com/juliandescottes/bidi-har-export.git#b2dc5b5d6fa90cdddb41c40681dc25119a37cd95",
-      "integrity": "sha512-LTO6Nwzf/MvvA32Uozr4FXECVivwJAV7Wjh0EA/wX7Cj5qoI1gu4/YsVUWNpc9ERFE3yhCSwuXXSOhjqxvinUw==",
-      "from": "bidi-har-export@juliandescottes/bidi-har-export#b2dc5b5d6fa90cdddb41c40681dc25119a37cd95"
+      "version": "git+ssh://git@github.com/firefox-devtools/bidi-har-export.git#b92585f39b6640ec93e57b0395b4dc22c2bde666",
+      "integrity": "sha512-HsPe74TZ8FdeRek1aaL8SEG+xy8i0cTHiHj1Vf1GjKPlRaPbj9dXrheN49Br5H++1hknSEoR2PorAEgWyfH3yw==",
+      "from": "bidi-har-export@firefox-devtools/bidi-har-export#b92585f39b6640ec93e57b0395b4dc22c2bde666"
     },
     "big.js": {
       "version": "5.2.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://lutien.github.io/bidi-webconsole-prototype",
   "dependencies": {
-    "bidi-har-export": "juliandescottes/bidi-har-export#b2dc5b5d6fa90cdddb41c40681dc25119a37cd95",
+    "bidi-har-export": "firefox-devtools/bidi-har-export#b92585f39b6640ec93e57b0395b4dc22c2bde666",
     "codemirror": "6.0.1",
     "@codemirror/lang-javascript": "6.1.0",
     "@codemirror/view": "6.2.5",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -71,6 +71,8 @@ class App extends React.Component {
 
     this.state = {
       activeTab: "console",
+      browserName: null,
+      browserVersion: null,
       browsingContexts: [],
       bidiLog: [],
       consoleInput: "",
@@ -244,8 +246,10 @@ class App extends React.Component {
       );
 
       // Store the session id
-      const sessionId = sessionNewResponse.result.sessionId;
+      const { capabilities, sessionId } = sessionNewResponse.result;
       localStorage.setItem("sessionId", sessionId);
+      localStorage.setItem("browserName", capabilities.browserName);
+      localStorage.setItem("browserVersion", capabilities.browserVersion);
     }
 
     // XXX: For existing sessions, we already subscribed to this in theory.
@@ -279,6 +283,8 @@ class App extends React.Component {
     const topContext = contextList[0];
     this.#evaluationBrowsingContextUrl = topContext.url;
     this.setState({
+      browserName: localStorage.getItem("browserName"),
+      browserVersion: localStorage.getItem("browserVersion"),
       browsingContexts: contextList,
       evaluationBrowsingContextId: topContext.context,
       isClientReady: true,
@@ -441,6 +447,8 @@ class App extends React.Component {
     const {
       activeTab,
       bidiLog,
+      browserName,
+      browserVersion,
       browsingContexts,
       consoleInput,
       consoleOutput,
@@ -483,6 +491,8 @@ class App extends React.Component {
         title: "Network",
         content: (
           <Network
+            browserName={browserName}
+            browserVersion={browserVersion}
             filteringBrowsingContextId={filteringBrowsingContextId}
             isClientReady={isClientReady}
             harEvents={harEvents}

--- a/src/components/Network.js
+++ b/src/components/Network.js
@@ -3,6 +3,8 @@ import NetworkFooter from "./NetworkFooter";
 import "./Network.css";
 
 const Network = ({
+  browserName,
+  browserVersion,
   filteringBrowsingContextId,
   harEvents,
   isClientReady,
@@ -66,6 +68,8 @@ const Network = ({
         )}
       </div>
       <NetworkFooter
+        browserName={browserName}
+        browserVersion={browserVersion}
         filteredHarEvents={events}
         filteredNetworkEntries={entries}
         filteredPageTimings={timings}

--- a/src/components/NetworkFooter.js
+++ b/src/components/NetworkFooter.js
@@ -5,8 +5,9 @@ import { adapters } from "bidi-har-export";
 
 class NetworkFooter extends React.Component {
   #onHarButtonClick = (events) => {
-    const exporter = new adapters.EventsCollectionExporter(events, {
+    const exporter = new adapters.EventsCollectionExporter({
       browser: "Firefox",
+      events,
       version: "111.0a1",
     });
     const har = exporter.exportAsHar();

--- a/src/components/NetworkFooter.js
+++ b/src/components/NetworkFooter.js
@@ -4,11 +4,11 @@ import "./NetworkFooter.css";
 import { adapters } from "bidi-har-export";
 
 class NetworkFooter extends React.Component {
-  #onHarButtonClick = (events) => {
+  #onHarButtonClick = (events, browserName, browserVersion) => {
     const exporter = new adapters.EventsCollectionExporter({
-      browser: "Firefox",
+      browser: browserName,
       events,
-      version: "111.0a1",
+      version: browserVersion,
     });
     const har = exporter.exportAsHar();
 
@@ -29,6 +29,8 @@ class NetworkFooter extends React.Component {
 
   render() {
     const {
+      browserName,
+      browserVersion,
       filteredHarEvents,
       filteredNetworkEntries,
       filteredPageTimings,
@@ -48,7 +50,7 @@ class NetworkFooter extends React.Component {
         </span>
         <span
           className="network-summary-item network-har-export-button"
-          onClick={() => this.#onHarButtonClick(filteredHarEvents)}
+          onClick={() => this.#onHarButtonClick(filteredHarEvents, browserName, browserVersion)}
         >
           Save all as HAR
         </span>


### PR DESCRIPTION
This PR updates our bidi-har-export dependency to use the repository under firefox-devtools and also attempts to read the browser name and version from the session new response instead of hardcoding it to firefox + 111.0a1